### PR TITLE
Upgraded to the latest play-partials

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -31,7 +31,7 @@ object HmrcBuild extends Build {
   val compile = Seq(
     "uk.gov.hmrc" %% "play-config" % "4.3.0",
     "uk.gov.hmrc" %% "logback-json-logger" % "3.1.0",
-    "uk.gov.hmrc" %% "play-partials" % "6.0.0",
+    "uk.gov.hmrc" %% "play-partials" % "6.1.0",
     "uk.gov.hmrc" %% "http-verbs" % "7.2.0"
   )
 

--- a/src/main/scala/uk/gov/hmrc/csp/WebchatClient.scala
+++ b/src/main/scala/uk/gov/hmrc/csp/WebchatClient.scala
@@ -38,15 +38,15 @@ object WebchatClient extends ServicesConfig {
   lazy val serviceUrl = baseUrl("csp-partials") + "/csp-partials"
 
 
-  def webchatOfferPartial()(implicit request: Request[_], ec: ExecutionContext): Html = {
+  def webchatOfferPartial()(implicit request: Request[_]): Html = {
     getPartialContent(serviceUrl + "/webchat-offers")
   }
 
-  def webchatClickToChatScriptPartial(entryPoint: String, template: String)(implicit request: Request[_], ec: ExecutionContext): Html = {
+  def webchatClickToChatScriptPartial(entryPoint: String, template: String)(implicit request: Request[_]): Html = {
     getPartialContent(serviceUrl + s"/webchat-click-to-chat/$entryPoint/$template")
   }
 
-  private def getPartialContent(url: String)(implicit request: Request[_], ec: ExecutionContext) = {
+  private def getPartialContent(url: String)(implicit request: Request[_]) = {
     val partialContent = CachedStaticHtmlPartialProvider.getPartialContent(url)
 
     partialContent.body match {


### PR DESCRIPTION
This allowed me to remove the ExecutionContext from the API, bringing back the compatibility with version 1.x.x of csp-client