### PR TITLE
Upgrade to latest sbt-auto-build plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,17 +17,13 @@
 import sbt.Keys.{libraryDependencies, _}
 import sbt._
 import uk.gov.hmrc.DefaultBuildSettings._
-import uk.gov.hmrc.{SbtArtifactory, SbtAutoBuildPlugin}
-import uk.gov.hmrc.versioning.SbtGitVersioning
-import uk.gov.hmrc.SbtArtifactory.autoImport.makePublicallyAvailableOnBintray
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
 val appName = "csp-client"
 
 lazy val microservice = Project(appName, file("."))
-  .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
   .settings(majorVersion := 4)
-  .settings(makePublicallyAvailableOnBintray := true)
+  .settings(isPublicArtefact := true)
   .settings(scalaSettings: _*)
   .settings(defaultSettings(): _*)
   .settings(
@@ -37,12 +33,6 @@ lazy val microservice = Project(appName, file("."))
         shared = sharedLibs,
         play25 = compilePlay25 ++ testCompilePlay25,
         play26 = compilePlay26 ++ testCompilePlay26
-    )
-  )
-  .settings(
-    resolvers := Seq(
-      Resolver.jcenterRepo,
-      Resolver.bintrayRepo("hmrc", "releases")
     )
   )
   .settings(PlayCrossCompilation.playCrossCompilationSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,18 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
+resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.16.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.19.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.19.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 


### PR DESCRIPTION
This commit provides the ability to build this project using 

* the latest version of the HMRC `set-auto-build` plugin 
* and a newer version for the `sbt-scoverage` plugin

It is necessary to produce test reports